### PR TITLE
Actions rockets

### DIFF
--- a/src/components/RocketItem.js
+++ b/src/components/RocketItem.js
@@ -1,16 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { rocketReserve, cancelReserve } from '../redux/rockets/RocketsSlice';
 
-const RocketItem = ({ rocket }) => (
-  <li className="rocketItem">
-    <img src={rocket.image} alt={rocket.name} />
-    <div className="itemDiv">
-      <h2>{rocket.name}</h2>
-      <p>{rocket.description}</p>
-      <button type="button">Reserve Rocket</button>
-    </div>
-  </li>
-);
+const RocketItem = ({ rocket }) => {
+  const dispatch = useDispatch();
+  return (
+    <li className="rocketItem">
+      <img src={rocket.image} alt={rocket.name} />
+      <div className="itemDiv">
+        <h2>{rocket.name}</h2>
+        {rocket.reserved && <div className="reserved">Reserved</div>}
+        <p>{rocket.description}</p>
+        {!rocket.reserved && <button type="button" onClick={() => dispatch(rocketReserve(rocket.id))}>Reserve Rocket</button>}
+        {rocket.reserved && <button type="button" onClick={() => dispatch(cancelReserve(rocket.id))}>Cancel Reservation</button>}
+      </div>
+    </li>
+  );
+};
 
 RocketItem.propTypes = {
   rocket: PropTypes.shape({
@@ -18,6 +25,7 @@ RocketItem.propTypes = {
     name: PropTypes.string,
     description: PropTypes.string,
     image: PropTypes.string,
+    reserved: PropTypes.bool,
   }).isRequired,
 };
 

--- a/src/components/RocketList.js
+++ b/src/components/RocketList.js
@@ -8,8 +8,7 @@ const RocketList = () => {
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(fetchRockets());
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [dispatch]);
 
   if (isLoading) {
     return (<h2 className="rocketLoading">Loading...</h2>);

--- a/src/redux/rockets/RocketsSlice.js
+++ b/src/redux/rockets/RocketsSlice.js
@@ -21,12 +21,26 @@ export const RocketsSlice = createSlice({
   name: 'rockets',
   initialState,
   reducers: {
-    rocketReserve: (state) => ({
-      ...state,
-    }),
-    cancelReserve: (state) => ({
-      ...state,
-    }),
+    rocketReserve: (state, action) => {
+      const newRockets = (state.rockets.map((rocket) => {
+        if (rocket.id !== action.payload) return rocket;
+        return { ...rocket, reserved: true };
+      }));
+      return ({
+        ...state,
+        rockets: newRockets,
+      });
+    },
+    cancelReserve: (state, action) => {
+      const newRockets = (state.rockets.map((rocket) => {
+        if (rocket.id !== action.payload) return rocket;
+        return { ...rocket, reserved: false };
+      }));
+      return ({
+        ...state,
+        rockets: newRockets,
+      });
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -42,6 +56,7 @@ export const RocketsSlice = createSlice({
             name: rocket.rocket_name,
             description: rocket.description,
             image: rocket.flickr_images[0],
+            reserved: false,
           })
         ));
         return {


### PR DESCRIPTION
In this pull request, I have implemented the following changes
- When a user clicks the "Reserve rocket" button, an action is dispatched to update the store (set `reserved` to true).
- When a user clicks the 'Cancel Reservation' button an action is dispatched to update the store (set `reserved` to false).